### PR TITLE
add -graphvizdot support

### DIFF
--- a/plantuml.rb
+++ b/plantuml.rb
@@ -43,13 +43,22 @@ module Jekyll
         puts "  -->\t" + status.inspect() + "\t" + result
       end
 
+      dotpath = site.config['plantuml_dotpath']
+      puts "using dot at: " + dotpath + "\n"
+      if File.exist?(dotpath)
+        puts "PlantUML set dot path:" + dotpath + "\n"
+        dotcmd = " -graphvizdot " + dotpath
+      else 
+        dotcmd = ""
+      end
+
       filename = Digest::MD5.hexdigest(code) + ".png"
       plantuml_jar = File.expand_path(site.config['plantuml_jar'])
       filepath = site.dest + folder + filename
       if File.exist?(filepath)
         puts "PlantUML image already exist: " + filepath + "\n"
       else
-        cmd = "java -jar " + plantuml_jar + " -pipe > " + filepath
+        cmd = "java -jar " + plantuml_jar + " -pipe > " + filepath + dotcmd
 
         result, status = Open3.capture2e(cmd, :stdin_data=>code)
         puts "  -->\t" + status.inspect() + "\t" + result


### PR DESCRIPTION
If the user installs graphviz with macports in Mac, the `dot` will be installed in `/opt/local/bin/dot`. But plantuml will invoke `dot` in `/usr/bin/dot`. So there will be some java errors during octopress generation.

My solution is to add a configuration parameter in _config.yml called 

```
plantuml_dotpath
```

to specify the `dot`  command path.
And then add the `-graphvizdot` option with the plantuml.jar.

What do you think?

BTW, maybe we need to notify the user to add the `public/images/plantuml` path in the clean task in Rakefile. Otherwise, the error picture will not be removed after generated.
