### PR TITLE
Fix aleung/jekyll-plantuml#1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add below configurations into `_config.yml`:
 plantuml:
   plantuml_jar: _bin/plantuml.jar     # path to plantuml jar
   tmp_folder: _plantuml               # tmp folder to put generated image files
-  dot_exe: _bin/dot.exe               # [optional] path to Graphviz dot execution
+  dot_exe: c:/graphviz/bin/dot.exe    # [optional] path to Graphviz dot execution
   background_color: white             # [optional] UML image background color
 ```
 

--- a/plantuml.rb
+++ b/plantuml.rb
@@ -35,14 +35,15 @@ module Jekyll
         puts "Create PlantUML image folder: " + folderpath + "\n"
       end
 
-      dotpath = File.expand_path(config['dot_exe'])
-      if File.exist?(dotpath)
-        puts "Use graphviz dot: " + dotpath + "\n"
-        dotcmd = " -graphvizdot " + dotpath
-      else 
-        dotcmd = ""
+      dotcmd = ""
+      if !config['dot_exe'].nil?
+        dotpath = File.expand_path(config['dot_exe'])
+        if File.exist?(dotpath)
+          puts "Use graphviz dot: " + dotpath + "\n"
+          dotcmd = " -graphvizdot " + dotpath
+        end
       end
-
+      
       filename = Digest::MD5.hexdigest(code) + ".png"
       filepath = tmproot + folder + filename
       if File.exist?(filepath)


### PR DESCRIPTION
Fix aleung/jekyll-plantuml#1 Configuration item `dot_exe` is not optional.
