### PR TITLE
Bug fix: not lookup dot from PATH.

### DIFF
--- a/plantuml.rb
+++ b/plantuml.rb
@@ -59,7 +59,7 @@ module Jekyll
     
     def dot_cmd
       @dot_cmd ||= begin
-        dotpath = File.expand_path(config['dot_exe'] || '')
+        dotpath = File.expand_path(config['dot_exe'] || '__NULL__')
         if File.exist?(dotpath)
           Jekyll.logger.info("PlantUML: Use graphviz dot: " + dotpath)
           " -graphvizdot " + dotpath


### PR DESCRIPTION
Fixed a bug: when `plantuml.dot_exe` isn't configured, the plugin doesn't use `dot` from PATH.
